### PR TITLE
Switch to fork of bumpr

### DIFF
--- a/.github/workflows/bumpr.yml
+++ b/.github/workflows/bumpr.yml
@@ -17,6 +17,6 @@ jobs:
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
-      - uses: haya14busa/action-bumpr@v1
+      - uses: jordemort/use-token-for-push@v1
         with:
           github_token: ${{ secrets.BUMPR_TOKEN }}


### PR DESCRIPTION
Upstream bumpr doesn't use the `github_token` for input, which means that the tags it push won't trigger any actions.