### PR TITLE
Abandon macos universal2 builds for arch-specific builds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -57,7 +57,7 @@ jobs:
           - os: macos-latest
             cibw_python: "cp37-*"
             cibw_arch: arm64
-        
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -77,6 +77,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 1
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -42,6 +42,13 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
         cibw_arch: ["x86_64", "aarch64", "arm64"]
+        include:
+          - cibw_arch: arm64
+            goarch: arm64
+          - cibw_arch: aarch64
+            goarch: arm64
+          - cibw_arch: x86_64
+            goarch: amd64
         exclude:
           - os: ubuntu-latest
             cibw_arch: arm64
@@ -69,6 +76,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
+          GOARCH: ${{ matrix.goarch }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,21 +41,15 @@ jobs:
         # Windows isn't working right now: https://github.com/caketop/python-starlark-go/issues/4
         os: [ubuntu-latest, macos-latest]
         cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
-        cibw_arch: ["x86_64", "aarch64", "universal2"]
+        cibw_arch: ["x86_64", "aarch64", "arm64"]
         exclude:
           - os: ubuntu-latest
-            cibw_arch: universal2
+            cibw_arch: arm64
           - os: macos-latest
             cibw_arch: aarch64
           - os: macos-latest
-            cibw_arch: x86_64
-          - os: macos-latest
             cibw_python: "cp37-*"
-            cibw_arch: universal2
-        include:
-          - os: macos-latest
-            cibw_python: "cp37-*"
-            cibw_arch: x86_64
+            cibw_arch: arm64
         
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
After messing with #131 for too long, @jordemort suggested a simpler route: ditch universal builds and stick to separate arches. This became easier after realizing that we'd need to use some tooling to combine the arm64 and x86_64 artifacts into one universal2 binary using `lipo`, and that would necessitate more changes to the build than it's worth.

Closes #131 