### PR TITLE
Revert "Limits Test PyPI Publish to when the token is defined (#133)"

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -121,7 +121,6 @@ jobs:
     name: Test publishing to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: secrets.TEST_PYPI_TOKEN != null && secrets.TEST_PYPI_TOKEN != ''
 
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This reverts https://github.com/caketop/python-starlark-go/pull/133 which was causing a (hard to notice, thanks GitHub) syntax error which was causing the entire workflow not to run.

Re: https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

> Secrets cannot be directly referenced in if: conditionals. Instead, consider setting secrets as job-level environment variables, then referencing the environment variables to conditionally run steps in the job. 

@colindean - If you want to take another pass at it, I guess that is the approach we'd need to use. It used to be that I could re-run jobs from pull requests and it would give the re-run a token, but that doesn't seem to be the case anymore. I might ask someone at GitHub if there is a way to do an "approval" thing that will let me loosen up access to the token there. For now, I'm just going to back the change out and let it fail when it fails.