### PR TITLE
Make ConversionErrors more useful

### DIFF
--- a/python_globals.go
+++ b/python_globals.go
@@ -2,8 +2,6 @@ package main
 
 /*
 #include "starlark.h"
-
-extern PyObject *ConversionError;
 */
 import "C"
 

--- a/src/starlark_go/__init__.py
+++ b/src/starlark_go/__init__.py
@@ -1,5 +1,7 @@
 from starlark_go.errors import (
     ConversionError,
+    ConversionToPythonFailed,
+    ConversionToStarlarkFailed,
     EvalError,
     ResolveError,
     ResolveErrorItem,
@@ -16,6 +18,8 @@ __all__ = [
     "Starlark",
     "StarlarkError",
     "ConversionError",
+    "ConversionToPythonFailed",
+    "ConversionToStarlarkFailed",
     "EvalError",
     "ResolveError",
     "ResolveErrorItem",

--- a/src/starlark_go/errors.py
+++ b/src/starlark_go/errors.py
@@ -185,10 +185,24 @@ class ResolveError(StarlarkError):
 
 class ConversionError(StarlarkError):
     """
-    A Starlark conversion error.
+    A base class for conversion errors.
+    """
 
-    This exception is raied by :py:meth:`starlark_go.Starlark.eval`,
-    :py:meth:`starlark_go.Starlark.get`, and :py:meth:`starlark_go.Starlark.set`
-    when a Starlark value can not be converted to a Python value, or when a
-    Python value can not be converted to a Starlark value.
+
+class ConversionToPythonFailed(ConversionError):
+    """
+    An error when converting a Starlark value to a Python value.
+
+    This exception is raied by :py:meth:`starlark_go.Starlark.eval`
+    and :py:meth:`starlark_go.Starlark.get when a Starlark value can
+    not be converted to a Python value.
+    """
+
+
+class ConversionToStarlarkFailed(ConversionError):
+    """
+    An error when converting a Python value to a Starlark value.
+
+    This exception is raied by :py:meth:`starlark_go.Starlark.set`
+    when a Python value can not be converted to a Starlark value.
     """

--- a/src/starlark_go/errors.py
+++ b/src/starlark_go/errors.py
@@ -194,7 +194,7 @@ class ConversionToPythonFailed(ConversionError):
     An error when converting a Starlark value to a Python value.
 
     This exception is raied by :py:meth:`starlark_go.Starlark.eval`
-    and :py:meth:`starlark_go.Starlark.get when a Starlark value can
+    and :py:meth:`starlark_go.Starlark.get` when a Starlark value can
     not be converted to a Python value.
     """
 

--- a/starlark.c
+++ b/starlark.c
@@ -22,7 +22,8 @@ PyObject *SyntaxError;
 PyObject *EvalError;
 PyObject *ResolveError;
 PyObject *ResolveErrorItem;
-PyObject *ConversionError;
+PyObject *ConversionToPythonFailed;
+PyObject *ConversionToStarlarkFailed;
 
 /* Wrapper for setting Starlark configuration options */
 static char *configure_keywords[] = {
@@ -555,8 +556,12 @@ PyMODINIT_FUNC PyInit_starlark_go(void)
   ResolveErrorItem = get_exception_class(errors, "ResolveErrorItem");
   if (ResolveErrorItem == NULL) return NULL;
 
-  ConversionError = get_exception_class(errors, "ConversionError");
-  if (ConversionError == NULL) return NULL;
+  ConversionToPythonFailed = get_exception_class(errors, "ConversionToPythonFailed");
+  if (ConversionToPythonFailed == NULL) return NULL;
+
+  ConversionToStarlarkFailed =
+      get_exception_class(errors, "ConversionToStarlarkFailed");
+  if (ConversionToStarlarkFailed == NULL) return NULL;
 
   PyObject *m;
   if (PyType_Ready(&StarlarkType) < 0) return NULL;

--- a/starlark.c
+++ b/starlark.c
@@ -100,7 +100,7 @@ PyDoc_STRVAR(
     "eval(self, expr, *, filename=None, convert=True, print=None)\n--\n\n"
     "Evaluate a Starlark expression. The expression passed to ``eval`` must evaluate "
     "to a value. Function definitions, variable assignments, and control structures "
-    "are not allowed by ``eval``. To use those, please use :func:`.exec`.\n\n"
+    "are not allowed by ``eval``. To use those, please use :meth:`exec`.\n\n"
     ":param expr: A string containing a Starlark expression to evaluate\n"
     ":type expr: str\n"
     ":param filename: An optional filename to use in exceptions, if evaluting the "

--- a/starlark.c
+++ b/starlark.c
@@ -114,6 +114,8 @@ PyDoc_STRVAR(
     "unspecified, Starlark's ``print()`` function will be forwarded to Python's "
     "built-in :py:func:`python:print`.\n"
     ":type print: typing.Callable[[str], typing.Any]\n"
+    ":raises ConversionToPythonFailed: if the value is of an unsupported type for "
+    "conversion.\n"
     ":raises EvalError: if there is a Starlark evaluation error\n"
     ":raises ResolveError: if there is a Starlark resolution error\n"
     ":raises SyntaxError: if there is a Starlark syntax error\n"
@@ -139,7 +141,6 @@ PyDoc_STRVAR(
     "unspecified, Starlark's ``print()`` function will be forwarded to Python's "
     "built-in :py:func:`python:print`.\n"
     ":type print: typing.Callable[[str], typing.Any]\n"
-    ":raises ConversionError: if the value is of an unsupported type for conversion.\n"
     ":raises EvalError: if there is a Starlark evaluation error\n"
     ":raises ResolveError: if there is a Starlark resolution error\n"
     ":raises SyntaxError: if there is a Starlark syntax error\n"
@@ -178,14 +179,15 @@ PyDoc_STRVAR(
     "For the aggregate types (``dict``, ``list``, ``set``, and ``tuple``,) all keys "
     "and/or values must also be one of the supported types.\n\n"
     "Attempting to get the value of any other Starlark type will raise a "
-    ":py:class:`ConversionError`.\n\n"
+    ":py:class:`ConversionToPythonFailed`.\n\n"
     ":param name: The name of the global variable.\n"
     ":type name: str\n"
     ":param default_value: A default value to return, if no global variable named "
     "``name`` is defined.\n"
     ":type default_value: typing.Any\n"
     ":raises KeyError: if there is no global value named ``name`` defined.\n"
-    ":raises ConversionError: if the value is of an unsupported type for conversion.\n"
+    ":raises ConversionToPythonFailed: if the value is of an unsupported type for "
+    "conversion.\n"
     ":rtype: typing.Any\n"
 );
 
@@ -227,8 +229,9 @@ PyDoc_STRVAR(
     "For the aggregate types (``dict``, ``list``, ``set``, and ``tuple``,) all keys "
     "and/or values must also be one of the supported types.\n\n"
     "Attempting to set a value of any other Python type will raise a "
-    ":py:class:`ConversionError`.\n\n"
-    ":raises ConversionError: if a value is of an unsupported type for conversion.\n"
+    ":py:class:`ConversionToStarlarkFailed`.\n\n"
+    ":raises ConversionToStarlarkFailed: if a value is of an unsupported type for "
+    "conversion.\n"
 );
 
 PyDoc_STRVAR(
@@ -244,7 +247,8 @@ PyDoc_STRVAR(
     "``name`` is defined.\n"
     ":type default_value: typing.Any\n"
     ":raises KeyError: if there is no global value named ``name`` defined.\n"
-    ":raises ConversionError: if the value is of an unsupported type for conversion.\n"
+    ":raises ConversionToPythonFailed: if the value is of an unsupported type for "
+    "conversion.\n"
     ":rtype: typing.Any\n"
 );
 

--- a/starlark.c
+++ b/starlark.c
@@ -100,7 +100,7 @@ PyDoc_STRVAR(
     "eval(self, expr, *, filename=None, convert=True, print=None)\n--\n\n"
     "Evaluate a Starlark expression. The expression passed to ``eval`` must evaluate "
     "to a value. Function definitions, variable assignments, and control structures "
-    "are not allowed by ``eval``. To use those, please use func:`exec`.\n\n"
+    "are not allowed by ``eval``. To use those, please use func:`.exec`.\n\n"
     ":param expr: A string containing a Starlark expression to evaluate\n"
     ":type expr: str\n"
     ":param filename: An optional filename to use in exceptions, if evaluting the "

--- a/starlark.c
+++ b/starlark.c
@@ -100,7 +100,7 @@ PyDoc_STRVAR(
     "eval(self, expr, *, filename=None, convert=True, print=None)\n--\n\n"
     "Evaluate a Starlark expression. The expression passed to ``eval`` must evaluate "
     "to a value. Function definitions, variable assignments, and control structures "
-    "are not allowed by ``eval``. To use those, please use func:`.exec`.\n\n"
+    "are not allowed by ``eval``. To use those, please use :func:`.exec`.\n\n"
     ":param expr: A string containing a Starlark expression to evaluate\n"
     ":type expr: str\n"
     ":param filename: An optional filename to use in exceptions, if evaluting the "

--- a/tests/test_conversion_to_python_failed.py
+++ b/tests/test_conversion_to_python_failed.py
@@ -1,0 +1,49 @@
+import pytest
+
+from starlark_go import ConversionToPythonFailed, Starlark
+
+STARLARK_SRC = """
+foo = print
+bar = [1, print, 2]
+baz = {"c": print}
+"""
+
+
+DONT_KNOW = "Don't know how to convert Starlark *starlark.Builtin to Python"
+LIST_INDEX_1 = (
+    "While converting value <built-in function print> at index 1 in Starlark list: "
+)
+DICT_KEY_C = (
+    'While converting value <built-in function print> of key "c" in Starlark dict: '
+)
+
+
+@pytest.fixture
+def s() -> Starlark:
+    starlark = Starlark()
+    starlark.exec(STARLARK_SRC, filename="fake.star")
+    return starlark
+
+
+def test_ConversionToPythonFailed(s: Starlark):
+    with pytest.raises(ConversionToPythonFailed) as e:
+        s.eval("print")
+    assert str(e.value) == DONT_KNOW
+
+    s.exec("foo = print")
+
+    with pytest.raises(ConversionToPythonFailed) as e:
+        s.get("foo")
+    assert str(e.value) == DONT_KNOW
+
+
+def test_ConversionToPythonFailed_bar(s: Starlark):
+    with pytest.raises(ConversionToPythonFailed) as e:
+        s.eval("bar")
+    assert str(e.value) == LIST_INDEX_1 + DONT_KNOW
+
+
+def test_ConversionToPythonFailed_baz(s: Starlark):
+    with pytest.raises(ConversionToPythonFailed) as e:
+        s.eval("baz")
+    assert str(e.value) == DICT_KEY_C + DONT_KNOW

--- a/tests/test_conversion_to_starlark_failed.py
+++ b/tests/test_conversion_to_starlark_failed.py
@@ -1,0 +1,64 @@
+from collections.abc import Sequence
+
+import pytest
+
+from starlark_go import ConversionToStarlarkFailed, Starlark
+
+foo = print
+bar = [1, print, 2]
+baz = {"c": print}
+
+
+DONT_KNOW = "Don't know how to convert Python builtin_function_or_method to Starlark"
+LIST_INDEX_1 = "While converting value at index 1 in Python list: "
+DICT_KEY_C = 'While converting value of key "c" in Python dict: '
+
+
+class ExplodingException(Exception):
+    pass
+
+
+class ExplodingSequence(Sequence[str]):
+    def __len__(self):
+        return 3
+
+    def __getitem__(self, key: int):
+        if key == 1:
+            raise ExplodingException("Surprise!")
+        return key * 100
+
+
+@pytest.fixture
+def s() -> Starlark:
+    starlark = Starlark()
+    return starlark
+
+
+def test_ConversionToStarlarkFailed(s: Starlark):
+    with pytest.raises(ConversionToStarlarkFailed) as e:
+        s.set(foo=foo)
+    assert str(e.value) == DONT_KNOW
+    assert getattr(e.value, "__cause__", None) is None
+
+
+def test_ConversionToStarlarkFailed_bar(s: Starlark):
+    with pytest.raises(ConversionToStarlarkFailed) as e:
+        s.set(bar=bar)
+    assert str(e.value) == LIST_INDEX_1 + DONT_KNOW
+    assert getattr(e.value, "__cause__", None) is None
+
+
+def test_ConversionToStarlarkFailed_baz(s: Starlark):
+    with pytest.raises(ConversionToStarlarkFailed) as e:
+        s.set(baz=baz)
+    assert str(e.value) == DICT_KEY_C + DONT_KNOW
+    assert getattr(e.value, "__cause__", None) is None
+
+
+def test_exploding_sequence(s: Starlark):
+    with pytest.raises(ConversionToStarlarkFailed) as e:
+        s.set(surprise=ExplodingSequence())
+    print(str(e.value))
+    assert isinstance(e.value, ConversionToStarlarkFailed)
+    assert hasattr(e.value, "__cause__")
+    assert isinstance(getattr(e.value, "__cause__"), ExplodingException)

--- a/tests/test_conversion_to_starlark_failed.py
+++ b/tests/test_conversion_to_starlark_failed.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from typing import Sequence
 
 import pytest
 


### PR DESCRIPTION
- Subclass into ConversionToPythonFailed and ConversionToStarlarkFailed
- Make messages much more informative and indicate which key or index failed
- If conversion fails because of a Python exception, add that exception as the source of ours

Closes #143