### PR TITLE
Allow passing parameters from tox to pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,15 +58,15 @@ python =
 deps =
   -r development.txt
   pytest-memray
-commands = pytest -v --memray
+commands = pytest -v --memray {posargs}
 
 [testenv:py37]
 deps = -r development.txt
-commands = pytest -v
+commands = pytest -v {posargs}
 
 [testenv:py312]
 deps = -r development.txt
-commands = pytest -v
+commands = pytest -v {posargs}
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This came in handy while working on https://github.com/caketop/python-starlark-go/pull/167