### PR TITLE
Use cgo.Handle for state

### DIFF
--- a/starlark.h
+++ b/starlark.h
@@ -9,7 +9,7 @@
 
 /* Starlark object */
 typedef struct Starlark {
-  PyObject_HEAD uint64_t state_id;
+  PyObject_HEAD uintptr_t handle;
 } Starlark;
 
 /* Helpers for Cgo, which can't handle varargs or macros */


### PR DESCRIPTION
Instead of keeping interpreter state in a homemade global map, use a library that is specifically designed for passing Go pointers back and forth to C.