### PR TITLE
Fix permissions in devcontainer?

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -83,7 +83,7 @@ ARG USERNAME
 
 RUN echo "set auto-load safe-path /" > /home/${USERNAME}/.gdbinit
 
-COPY --from=go_tools /home/${USERNAME}/go/bin/ /home/${USERNAME}/go/bin
+COPY --from=go_tools --chown=${USERNAME} /home/${USERNAME}/go/bin/ /home/${USERNAME}/go/bin
 
 RUN python3.10 -m venv /home/${USERNAME}/venv
 
@@ -91,9 +91,9 @@ ENV PATH=/home/${USERNAME}/venv/bin:/opt/python/cp310-cp310/bin:${PATH}
 
 RUN python3.10 -m pip install black ipython isort memray pytest pytest-memray pytest-valgrind tox
 
-COPY --from=misc /tmp/shellcheck/shellcheck /home/${USERNAME}/.local/bin/shellcheck
-COPY --from=misc /tmp/mcfly/mcfly /home/${USERNAME}/.local/bin/mcfly
-COPY --from=misc /tmp/clang/bin/clang-format /home/${USERNAME}/.local/bin/clang-format
+COPY --from=misc --chown=${USERNAME} /tmp/shellcheck/shellcheck /home/${USERNAME}/.local/bin/shellcheck
+COPY --from=misc --chown=${USERNAME} /tmp/mcfly/mcfly /home/${USERNAME}/.local/bin/mcfly
+COPY --from=misc --chown=${USERNAME} /tmp/clang/bin/clang-format /home/${USERNAME}/.local/bin/clang-format
 
 RUN echo 'eval "$(mcfly init bash)"' >> ~/.bashrc && touch ~/.bash_history
 RUN echo 'eval "$(starship init bash)"' >> ~/.bashrc


### PR DESCRIPTION
This is my first time using [devcontainers](https://containers.dev/) and I rarely use Visual Studio Code, so I might be doing something wrong. Feel free to close this PR.

# Problem
When I tried to open this repo in a dev container in Visual Studio Code, I got lots of permission errors. 

For example, if I try to build the current Go package or Go workspace:

```
Starting‘ building the current workspace at /workspaces/python-starlark-go
/workspaces/python-starlark-go>Finished running tool: /opt/go/bin/go build
go: could not create module cache: mkdir /home/builder/go/pkg: permission denied
go: could not create module cache: mkdir /home/builder/go/pkg: permission denied
```

```
Starting building the current package at /workspaces/python-starlark-go
/workspaces/python-starlark-go>Finished running tool: /opt/go/bin/go build -o /tmp/vscode-gosVaJUu/go-code-check .
go: could not create module cache: mkdir /home/builder/go/pkg: permission denied
go: could not create module cache: mkdir /home/builder/go/pkg: permission denied
go: could not create module cache: mkdir /home/builder/go/pkg: permission denied
```

I also get errors to do with `shellcheck` and `mcfly` whenever I run any command in the terminal.

# Solution
I made these changes to the Dockerfile by trial and error. It seems to work for me now, e.g.:
```
Starting building the current package at /workspaces/python-starlark-go
/workspaces/python-starlark-go>Finished running tool: /opt/go/bin/go build -o /tmp/vscode-goL28DLO/go-code-check .
```