### PR TITLE
Upgrade starlark-go (20240311180835-efac67204ba7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/caketop/python-starlark-go
 
 go 1.20
 
-require go.starlark.net v0.0.0-20230302034142-4b1e35fe2254
+require go.starlark.net v0.0.0-20240311180835-efac67204ba7
 
 require golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,10 @@ go.starlark.net v0.0.0-20230128213706-3f75dec8e403 h1:jPeC7Exc+m8OBJUlWbBLh0O5UZ
 go.starlark.net v0.0.0-20230128213706-3f75dec8e403/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 h1:Ss6D3hLXTM0KobyBYEAygXzFfGcjnmfEJOBgSbemCtg=
 go.starlark.net v0.0.0-20230302034142-4b1e35fe2254/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
+go.starlark.net v0.0.0-20240123142251-f86470692795 h1:LmbG8Pq7KDGkglKVn8VpZOZj6vb9b8nKEGcg9l03epM=
+go.starlark.net v0.0.0-20240123142251-f86470692795/go.mod h1:LcLNIzVOMp4oV+uusnpk+VU+SzXaJakUuBjoCSWH5dM=
+go.starlark.net v0.0.0-20240311180835-efac67204ba7 h1:xH7OJPtjgdj/xXykge/wGPAAqik97FbEVJR55lEY0tQ=
+go.starlark.net v0.0.0-20240311180835-efac67204ba7/go.mod h1:MrdO7XaMF3dE3MzuP6mrG0EB3NC7rLWSiEcu9Ii50g8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -19,13 +19,14 @@ def fibonacci(n):
 
 def test_recursion():
     s = Starlark()
-    s.exec(RFIB)
 
     configure_starlark(allow_recursion=False)
+    s.exec(RFIB)
     with pytest.raises(EvalError):
         s.eval("fibonacci(5)")
 
     configure_starlark(allow_recursion=True)
+    s.exec(RFIB)
     assert s.eval("fibonacci(5)") == [0, 1, 1, 2, 3]
     assert s.eval("fibonacci(10)") == [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
 


### PR DESCRIPTION
Upgrade the Go starlark package to the latest one. 
This involves a rewrite of the `test_configure.py` since the starlark resolver configuration is evaluated part of the exec. Using global config vars is deprecated and should be replaced. Not part of this PR as it would involve a breaking change of the API.