### PR TITLE
Use pypa/cibuildwheel 2.23.1, which may get musllinux support

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -75,7 +75,7 @@ jobs:
         uses: docker/setup-qemu-action@v3.0.0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.23.1
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: ${{ matrix.cibw_python }}


### PR DESCRIPTION
I've got a need for musl use now…

I _think_ this is sufficient after reading https://github.com/pypa/cibuildwheel, but I suspect there might be something on the Go side that might throw it off.